### PR TITLE
Add URI scheme configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Download the release `.zip` and install into `wp-content/plugins`.
 
 ## Usage
 
-Pretty straight forward usage. You can optionally set a default country.
+Pretty straight forward usage. You can optionally set a default country and default URI scheme.
 
 Calling the field will return an [arrayable](https://github.com/Log1x/acf-phone-number/blob/master/src/PhoneNumber.php#L225-L246) object containing everything you need about your number:
 
@@ -50,6 +50,14 @@ Calling the field will return an [arrayable](https://github.com/Log1x/acf-phone-
 }
 ```
 
+Alternatively, you can retrieve the phone number data by calling the object's available methods, such as `PhoneNumber->uri()`.
+
+```php
+<?php get_field('my_number_field)->uri(); ?>
+```
+
+To see the other methods available, view `src/PhoneNumber.php`.
+
 ### ACF Composer
 
 If you are on Sage 10 and using my [ACF Composer](https://github.com/log1x/acf-composer) package:
@@ -57,7 +65,8 @@ If you are on Sage 10 and using my [ACF Composer](https://github.com/log1x/acf-c
 ```php
 $field
   ->addField('my_number_field', 'phone_number')
-    ->setConfig('default_country', 'us');
+    ->setConfig('default_country', 'us')
+    ->setConfig('default_uri_scheme', 'tel');
 ```
 
 ## Bug Reports

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -27,6 +27,13 @@ class PhoneNumber
     protected $number;
 
     /**
+     * The URI scheme.
+     *
+     * @var string
+     */
+    protected $uri_scheme;
+
+    /**
      * Create a new phone number instance.
      *
      * @param  string $number
@@ -48,7 +55,7 @@ class PhoneNumber
      * @return $this
      */
     public function parse($value = null)
-    {
+    {       
         if (
             ! is_array($value) ||
             empty($value['number']) ||
@@ -62,6 +69,10 @@ class PhoneNumber
         } catch (NumberParseException $e) {
             //
         }
+
+        var_dump($value);
+        
+        $this->uri_scheme = $value['uri_scheme'] ?? 'tel';
 
         return $this;
     }
@@ -77,7 +88,7 @@ class PhoneNumber
             return '';
         }
 
-        return 'tel:' . $this->instance->format(
+        return $this->uri_scheme . ':' . $this->instance->format(
             $this->number,
             PhoneNumberFormat::E164
         );

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -55,7 +55,7 @@ class PhoneNumber
      * @return $this
      */
     public function parse($value = null)
-    {       
+    {
         if (
             ! is_array($value) ||
             empty($value['number']) ||
@@ -69,7 +69,7 @@ class PhoneNumber
         } catch (NumberParseException $e) {
             //
         }
-        
+
         $this->uri_scheme = $value['uri_scheme'] ?? 'tel';
 
         return $this;

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -69,8 +69,6 @@ class PhoneNumber
         } catch (NumberParseException $e) {
             //
         }
-
-        var_dump($value);
         
         $this->uri_scheme = $value['uri_scheme'] ?? 'tel';
 

--- a/src/PhoneNumberField.php
+++ b/src/PhoneNumberField.php
@@ -69,7 +69,7 @@ class PhoneNumberField extends \acf_field
         if (empty($field['value']['uri_scheme'])) {
             $field['value']['uri_scheme'] = $field['default_uri_scheme'] ?? $this->defaults['uri_scheme'];
         }
-        
+
         echo sprintf(
             '<input type="tel" name="%s[number]" value="%s" />',
             $field['name'],
@@ -82,13 +82,13 @@ class PhoneNumberField extends \acf_field
             $field['name'],
             $field['value']['country'] ?? $field['default_country'] ?? $this->defaults['country']
         );
-        
+
         echo sprintf(
             '<input data-default-uri-scheme="%s" type="hidden" name="%s[uri_scheme]" value="%s" />',
             $field['default_uri_scheme'] ?? $this->defaults['uri_scheme'],
             $field['name'],
             $field['value']['uri_scheme'] ?? $field['default_uri_scheme'] ?? $this->defaults['uri_scheme']
-        ); 
+        );
     }
 
     /**
@@ -119,7 +119,7 @@ class PhoneNumberField extends \acf_field
             'choices' => [
                 'tel' => 'Telephone',
                 'fax' => 'Fax',
-            ]                
+            ]
         ]);
     }
 

--- a/src/PhoneNumberField.php
+++ b/src/PhoneNumberField.php
@@ -32,6 +32,7 @@ class PhoneNumberField extends \acf_field
      */
     public $defaults = [
         'country' => 'us',
+        'uri_scheme' => 'tel',
     ];
 
     /**
@@ -65,6 +66,10 @@ class PhoneNumberField extends \acf_field
             $field['value']['country'] = $field['default_country'] ?? $this->defaults['country'];
         }
 
+        if (empty($field['value']['uri_scheme'])) {
+            $field['value']['uri_scheme'] = $field['default_uri_scheme'] ?? $this->defaults['uri_scheme'];
+        }
+        
         echo sprintf(
             '<input type="tel" name="%s[number]" value="%s" />',
             $field['name'],
@@ -77,6 +82,13 @@ class PhoneNumberField extends \acf_field
             $field['name'],
             $field['value']['country'] ?? $field['default_country'] ?? $this->defaults['country']
         );
+        
+        echo sprintf(
+            '<input data-default-uri-scheme="%s" type="hidden" name="%s[uri_scheme]" value="%s" />',
+            $field['default_uri_scheme'] ?? $this->defaults['uri_scheme'],
+            $field['name'],
+            $field['value']['uri_scheme'] ?? $field['default_uri_scheme'] ?? $this->defaults['uri_scheme']
+        ); 
     }
 
     /**
@@ -95,6 +107,19 @@ class PhoneNumberField extends \acf_field
             'name' => 'default_country',
             'default_value' => $this->defaults['country'],
             'choices' => (new PhoneNumber())->getCountries()
+        ]);
+
+        acf_render_field_setting($field, [
+            'label' => __('Default URI Scheme', 'acf-phone-number'),
+            'instructions' => __('The default URI scheme for the phone number.', 'acf-phone-number'),
+            'type' => 'select',
+            'ui' => 1,
+            'name' => 'default_uri_scheme',
+            'default_value' => $this->defaults['uri_scheme'],
+            'choices' => [
+                'tel' => 'Telephone',
+                'fax' => 'Fax',
+            ]                
         ]);
     }
 


### PR DESCRIPTION
This PR adds the ability to configure the URI scheme returned by `PhoneNumber->uri()`. By default, the scheme is set to `tel`. By using ACF Composer (tested) or the conventional ACF field configuration process (untested), the uri scheme can be set to any user-given value. 

Side note: Given that this field can work with facsimile just as well with phone, it might make sense to rename the project to `acf-telephony`. Thoughts?   

Question: does the user-given value need to be validated/escaped?  