### PR TITLE
Fix required no error on empty

### DIFF
--- a/src/PhoneNumberField.php
+++ b/src/PhoneNumberField.php
@@ -153,7 +153,7 @@ class PhoneNumberField extends \acf_field
     public function validate_value($valid, $value, $field, $input)
     {
         if (! is_array($value) || empty($value['number'])) {
-            return $valid;
+            return __('The phone number cannot be empty.', 'acf-phone-number');
         }
 
         if (empty($value['country'])) {


### PR DESCRIPTION
`$valid` was returned as `true`, even if the number was empty.