### PR TITLE
fix(acp): Change `get_field_type()` to `get_acf_field_option()`

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: Advanced Custom Fields: Phone Number
  * Plugin URI:  https://github.com/log1x/acf-phone-number
  * Description: A real ACF phone number field.
- * Version:     1.1.7
+ * Version:     1.1.8
  * Author:      Brandon Nifong
  * Author URI:  https://github.com/log1x
  */
@@ -66,7 +66,7 @@ add_filter('after_setup_theme', new class
         add_filter('ac/column/value', function ($value, $id, $column) {
             if (
                 ! is_a($column, '\ACA\ACF\Column') ||
-                $column->get_field_type() !== 'phone_number'
+                $column->get_acf_field_option('type') !== 'phone_number'
             ) {
                 return $value;
             }


### PR DESCRIPTION
This seemed to of worked before but is now throwing an error for me. No idea if/when it was changed. This appears to be the proper fix and is working on my end.

## Change log

### Bug fixes

- fix(acp): Change `get_field_type()` to `get_acf_field_option()` as per admin columns hook example.